### PR TITLE
Remove hardcoded region from task definition

### DIFF
--- a/ecsworkshop/task_definition.json
+++ b/ecsworkshop/task_definition.json
@@ -6,7 +6,7 @@
         "logDriver": "awslogs",
         "options": {
           "awslogs-group": "{{LOGGROUPNAME}}",
-          "awslogs-region": "((AWS_REGION}}",
+          "awslogs-region": "{{AWS_REGION}}",
           "awslogs-stream-prefix": "ecs"
         }
       },

--- a/ecsworkshop/task_definition.json
+++ b/ecsworkshop/task_definition.json
@@ -6,7 +6,7 @@
         "logDriver": "awslogs",
         "options": {
           "awslogs-group": "{{LOGGROUPNAME}}",
-          "awslogs-region": "{{AWS_REGION}}",
+          "awslogs-region": "{{REGION}}",
           "awslogs-stream-prefix": "ecs"
         }
       },

--- a/ecsworkshop/task_definition.json
+++ b/ecsworkshop/task_definition.json
@@ -6,7 +6,7 @@
         "logDriver": "awslogs",
         "options": {
           "awslogs-group": "{{LOGGROUPNAME}}",
-          "awslogs-region": "us-west-2",
+          "awslogs-region": "((AWS_REGION}}",
           "awslogs-stream-prefix": "ecs"
         }
       },


### PR DESCRIPTION
Hello,
If you look for `us-west-2` throughout this repository you'll find it in
* [[step_2/task_definition.json.console]](step_2/task_definition.json.console) and
* [step_2/task_definition.json.hardcoded](step_2/task_definition.json.hardcoded)

Not sure if that's intended or not.

Cheers,
krisstef@